### PR TITLE
Added default parameters for name and URL

### DIFF
--- a/api/datasources/node-red.ds.js
+++ b/api/datasources/node-red.ds.js
@@ -68,6 +68,17 @@ const datasource = {
                 }
                 return cb(null, body);
             });
+        },
+        'delete': (id, cb) => {
+
+            Wreck.delete(`/flow/${id}`, (err, response, body) => {
+
+                if (err) {
+                    errorHandler(new Error(err));
+                    return cb(err);
+                }
+                return cb(null, body);
+            });
         }
     }
 };

--- a/api/models/flow-template.model.js
+++ b/api/models/flow-template.model.js
@@ -12,7 +12,7 @@ const schema = {
     deprecated: Joi.boolean(),
     name: Joi.string().description('Name of the Flow (this is unique)'),
     description: Joi.string().description('Description of the Flow Template'),
-    parameters: Joi.array().items(Joi.string()).description('List of Parameters'),
+    parameters: Joi.array().items(Joi.string().regex(/^[^_].+/, 'allowed parameter name')).description('List of Parameters'),
     flow: Joi.object().keys({
         label: Joi.string(),
         nodes: Joi.array().items(Joi.object())
@@ -167,13 +167,9 @@ class FlowTemplateModel {
             type: 'default',
             body: {
                 'query': {
-                    'match': {
-                        'name': {
-                            'query': name,
-                            'operator': 'and'
-                        }
+                    'term': {
+                        'name.keyword': name
                     }
-
                 }
             }
 

--- a/api/models/flow.model.js
+++ b/api/models/flow.model.js
@@ -80,6 +80,10 @@ class FlowModel {
             return cb(error);
         }
 
+        //include system parameters
+        parameters._url = encodeURIComponent(flowModel.name);
+        parameters._name = flowModel.name;
+
         const saveES = (newFlow, next) => {
 
             const values = {
@@ -258,13 +262,9 @@ class FlowModel {
             type: 'default',
             body: {
                 'query': {
-                    'match': {
-                        'name': {
-                            'query': name,
-                            'operator': 'and'
-                        }
+                    'term': {
+                        'name.keyword': name
                     }
-
                 }
             }
 

--- a/api/modules/node-red-proxy/controllers/all.node-red-proxy.controller.js
+++ b/api/modules/node-red-proxy/controllers/all.node-red-proxy.controller.js
@@ -1,6 +1,5 @@
 'use strict';
 const Boom = require('boom');
-const _ = require('lodash');
 const Flow = require('../../../models').Flow;
 module.exports = (request, reply) => {
 
@@ -15,9 +14,8 @@ module.exports = (request, reply) => {
             console.log(new Error('Flow not found'));
             return reply(Boom.badRequest('Flow Template not found'));
         }
-        const urlParameter = _.find(flow.parameters, ['key', 'url']);
         return reply.proxy({
-            uri: `${process.env.NODE_RED_URL}/${urlParameter.value}`
+            uri: `${process.env.NODE_RED_URL}/${encodeURI(flow.name)}`
         });
     });
 };

--- a/api/test/helpers/flow-template.helper.js
+++ b/api/test/helpers/flow-template.helper.js
@@ -3,10 +3,10 @@
 const ES = require('../../datasources').Elasticsearch;
 const _ = require('lodash');
 const defaultData = {
-    'name': 'anduin-executions',
+    'name': 'test-template',
     'description': 'Anduin Executions can be posted here for storage and use in Samson',
-    'parameters': ['channelName', 'url'],
-    'flow': '{"label":"flow-{{channelName}}-{{_id}}","nodes":[{"id":"{{channelName}}-1-{{_id}}","type":"http in","z":"96c7bac4.7985d8","name":"","url":"/{{url}}","method":"post","swaggerDoc":"","x":356,"y":455,"wires":[["{{channelName}}-3-{{_id}}","{{channelName}}-4-{{_id}}"]]},{"id":"{{channelName}}-2-{{_id}}","type":"http response","z":"96c7bac4.7985d8","name":"","x":646,"y":455,"wires":[]},{"id":"{{channelName}}-3-{{_id}}","type":"function","z":"96c7bac4.7985d8","name":"","func":"msg.payload = \\"Test Channel1\\";\\n\\nreturn msg;","outputs":1,"noerr":0,"x":506,"y":427,"wires":[["{{channelName}}-2-{{_id}}"]]},{"id":"{{channelName}}-4-{{_id}}","type":"debug","z":"96c7bac4.7985d8","name":"debug","active":true,"console":"false","complete":"true","x":513.5,"y":514,"wires":[]}]}',
+    'parameters': ['message'],
+    'flow': '{"label":"flow-{{_name}}-{{_id}}","nodes":[{"id":"{{_name}}-1-{{_id}}","type":"http in","z":"96c7bac4.7985d8","name":"","url":"/{{_url}}","method":"post","swaggerDoc":"","x":356,"y":455,"wires":[["{{_name}}-3-{{_id}}","{{_name}}-4-{{_id}}"]]},{"id":"{{_name}}-2-{{_id}}","type":"http response","z":"96c7bac4.7985d8","name":"","x":646,"y":455,"wires":[]},{"id":"{{_name}}-3-{{_id}}","type":"function","z":"96c7bac4.7985d8","name":"","func":"msg.payload = \\"Test Channel1\\";\\n\\nreturn msg;","outputs":1,"noerr":0,"x":506,"y":427,"wires":[["{{_name}}-2-{{_id}}"]]},{"id":"{{_name}}-4-{{_id}}","type":"debug","z":"96c7bac4.7985d8","name":"debug","active":true,"console":"false","complete":"true","x":513.5,"y":514,"wires":[]}]}',
     'version': 1
 };
 

--- a/api/test/helpers/flow.helper.js
+++ b/api/test/helpers/flow.helper.js
@@ -1,15 +1,16 @@
 'use strict';
 
 const ES = require('../../datasources').Elasticsearch;
+const NR = require('../../datasources').NodeRED;
 const _ = require('lodash');
 const defaultData =
     {
         'version': 1,
-        'template': 'AVyCPw5pizmIbsE8o-4r',
+        'template': '',
         'templateVersion': 1,
-        'name': 'anduin-executions-channel',
+        'name': 'test-helper',
         'description': 'Anduin Executions can be posted here for storage and use in Samson',
-        'parameters': [{ 'key': 'channelName', 'value': 'test name' }, { 'key': 'url', 'value': 'url-path' }]
+        'parameters': [{ 'key': 'message', 'value': 'test message' }]
     };
 
 const helper = {
@@ -31,13 +32,24 @@ const helper = {
             return cb(null, result);
         });
     },
-    'delete': (id, cb) => {
+    'deleteES': (id, cb) => {
 
         ES.delete({
             index: process.env.ES_INDEX,
             type: 'default',
             id
         }, (err) => {
+
+            if (err) {
+                return cb(err);
+            }
+
+            return cb();
+        });
+    },
+    'deleteNR': (id, cb) => {
+
+        NR.flow.delete(id, (err) => {
 
             if (err) {
                 return cb(err);

--- a/api/test/modules/flow-template.routes.test.js
+++ b/api/test/modules/flow-template.routes.test.js
@@ -1,3 +1,4 @@
+
 'use strict';
 require('dotenv').config({ path: '../../../.env' });
 const Code = require('code');
@@ -221,6 +222,34 @@ suite('/flowTemplate', () => {
                 done();
             });
         });
+
+        test('should respond with 400 Bad Request of using and invalid parameter name with _', (done) => {
+
+            const data = {
+                name: `${FlowTemplateHelper.defaultData.name}-1-${testData.key}`,
+                description: 'Anduin Executions can be posted here for storage and use in Samson',
+                parameters: ['_url'],
+                flow: {
+                    label: 'Test',
+                    nodes: [
+                        {
+                            test: 'Test'
+                        }
+                    ]
+                }
+            };
+            const options = {
+                method: 'POST',
+                url: '/flowTemplate',
+                payload: data
+            };
+
+            server.inject(options, (res) => {
+
+                expect(res.statusCode).to.equal(400);
+                expect(res.result.error).to.equal('Bad Request');
+                done();
+            });
+        });
     });
 });
-

--- a/api/test/modules/flow.routes.test.js
+++ b/api/test/modules/flow.routes.test.js
@@ -68,7 +68,8 @@ after((done) => {
 
     Async.parallel([
         (cb) => FlowTemplateHelper.delete(testData.flowTemplate._id, cb),
-        (cb) => FlowHelper.delete(testData.flow._id, cb)
+        (cb) => FlowHelper.deleteES(testData.flow._id, cb),
+        (cb) => FlowHelper.deleteNR(testData.flow.nodeRedId, cb)
 
     ], done);
 
@@ -111,12 +112,12 @@ suite('/flow', () => {
         test('should respond with 404 Flow not found', (done) => {
 
             const data = {
-                id: '-1'
+                name: 'test-helper'
             };
 
             const options = {
                 method: 'GET',
-                url: `/flow/${data.id}`
+                url: `/flow/${data.name}`
             };
 
             server.inject(options, (res) => {
@@ -138,11 +139,8 @@ suite('/flow', () => {
                 description: 'Anduin Executions can be posted here for storage and use in Samson',
                 parameters: [
                     {
-                        key: 'channelName',
-                        value: 'testname'
-                    }, {
-                        key: 'url',
-                        value: 'url-path'
+                        key: 'message',
+                        value: 'test message'
                     }
                 ]
             };
@@ -156,7 +154,11 @@ suite('/flow', () => {
 
                 expect(res.statusCode).to.equal(200);
                 expect(res.result).to.be.an.object();
-                FlowHelper.delete(res.result.id, done);
+
+                Async.parallel([
+                    (cb) => FlowHelper.deleteES(res.result.id, cb),
+                    (cb) => FlowHelper.deleteNR(res.result.nodeRedId, cb)
+                ], done);
             });
         });
 
@@ -267,4 +269,5 @@ suite('/flow', () => {
             });
         });
     });
+
 });


### PR DESCRIPTION
Issue #32

Added 3 `system variable` that can be used in the template:
`_id` => Id generated by ES
`_url` => URL encoded name
`_name` => just the name
 
# Testing

## Flow Template
```
curl -X POST \
  http://0.0.0.0:4000/flowTemplate \
  -d '{
  "name": "sample-executions-template",
  "description": "Sample Executions can be posted here for storage and use in ES",
  "parameters": ["message"],
  "flow": {
    "label": "flow-{{_name}}-{{_id}}",
    "nodes": [
      {
        "id": "{{_name}}-1-{{_id}}",
        "type": "http in",
        "z": "96c7bac4.7985d8",
        "name": "",
        "url": "\/{{_url}}",
        "method": "post",
        "swaggerDoc": "",
        "x": 356,
        "y": 455,
        "wires": [
          [
            "{{_name}}-3-{{_id}}",
            "{{_name}}-4-{{_id}}"
          ]
        ]
      },
      {
        "id": "{{_name}}-2-{{_id}}",
        "type": "http response",
        "z": "96c7bac4.7985d8",
        "name": "",
        "x": 646,
        "y": 455,
        "wires": []
      },
      {
        "id": "{{_name}}-3-{{_id}}",
        "type": "function",
        "z": "96c7bac4.7985d8",
        "name": "",
        "func": "msg.payload = \"{{message}}\";\n\nreturn msg;",
        "outputs": 1,
        "noerr": 0,
        "x": 506,
        "y": 427,
        "wires": [
          [
            "{{_name}}-2-{{_id}}"
          ]
        ]
      },
      {
        "id": "{{_name}}-4-{{_id}}",
        "type": "debug",
        "z": "96c7bac4.7985d8",
        "name": "debug",
        "active": true,
        "console": "false",
        "complete": "true",
        "x": 513.5,
        "y": 514,
        "wires": []
      }
    ]
  }

}'
```

## Flow
```
curl -X POST \
  http://0.0.0.0:4000/flow \
  -H 'accept: application/json' \
  -H 'cache-control: no-cache' \
  -H 'content-type: application/json' \
  -H 'postman-token: 8bb21f62-4584-bd8d-9c0e-c57b5e1e4d53' \
  -d '{
    "template": "sample-executions-template",
    "name": "sample-executions-channel test",
    "description": "Sample Executions can be posted here for storage and use in ES-2",
    "parameters": [
        {
            "key": "message",
            "value": "test message"
        }
    ]
}'
```

## Testing proxy
```
curl -X POST \
  http://0.0.0.0:4000/flow/sample-executions-channel%20test/data
```
